### PR TITLE
Clear cache unless it's for local development

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,5 @@
 {
   "tasks": {
-    "dev": "deno run -A --unstable-sloppy-imports main.ts"
+    "dev": "deno run -A --unstable-sloppy-imports main.ts local"
   }
 }

--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,5 @@
 {
   "tasks": {
-    "dev": "deno run -A --unstable-sloppy-imports main.ts local"
+    "dev": "deno run -A --unstable-sloppy-imports main.ts"
   }
 }

--- a/lib/useCache.ts
+++ b/lib/useCache.ts
@@ -7,7 +7,7 @@ import {
   type Stream,
   stream,
 } from "npm:effection@3.0.3";
-import { ensureFile, exists, walkSync } from "jsr:@std/fs@1.0.4";
+import { ensureFile, exists, walkSync, emptyDir } from "jsr:@std/fs@1.0.4";
 import { basename, dirname, globToRegExp, join } from "jsr:@std/path@1.0.6";
 
 import { JSONLinesParseStream } from './jsonlines/parser.ts';
@@ -117,8 +117,6 @@ class PersistantCache implements Cache {
 
   *clear({ full }: { full: boolean }) {
     const path = full ? this.location : `${this.location.pathname}discussions`;
-    yield* call(() => {
-      Deno.remove(path, { recursive: true });
-    });
+    yield* call(() => emptyDir(path));
   }
 }

--- a/lib/useCache.ts
+++ b/lib/useCache.ts
@@ -116,7 +116,10 @@ class PersistantCache implements Cache {
   }
 
   *clear({ full }: { full: boolean }) {
-    const path = full ? this.location : `${this.location.pathname}discussions`;
-    yield* call(() => emptyDir(path));
+    if (full) {
+      yield* call(() => emptyDir(this.location));
+    } else {
+      yield* call(() => emptyDir(new URL(`/discussions/`, this.location)))
+    }
   }
 }

--- a/lib/useCache.ts
+++ b/lib/useCache.ts
@@ -18,6 +18,7 @@ interface Cache {
   read<T>(key: string): Operation<Stream<T, unknown>>;
   has(key: string): Operation<boolean>;
   find<T>(directory: string): Stream<T, unknown>;
+  clear(): Operation<void>;
 }
 
 export const CacheContext = createContext<Cache>("cache");
@@ -112,5 +113,11 @@ class PersistantCache implements Cache {
     });
 
     return queue;
+  }
+
+  *clear() {
+    yield* call(() => {
+      Deno.remove(this.location, { recursive: true });
+    });
   }
 }

--- a/lib/useCache.ts
+++ b/lib/useCache.ts
@@ -18,7 +18,7 @@ interface Cache {
   read<T>(key: string): Operation<Stream<T, unknown>>;
   has(key: string): Operation<boolean>;
   find<T>(directory: string): Stream<T, unknown>;
-  clear(): Operation<void>;
+  clear({ full }: { full: boolean }): Operation<void>;
 }
 
 export const CacheContext = createContext<Cache>("cache");
@@ -115,9 +115,10 @@ class PersistantCache implements Cache {
     return queue;
   }
 
-  *clear() {
+  *clear({ full }: { full: boolean }) {
+    const path = full ? this.location : `${this.location.pathname}discussions`;
     yield* call(() => {
-      Deno.remove(this.location, { recursive: true });
+      Deno.remove(path, { recursive: true });
     });
   }
 }

--- a/main.ts
+++ b/main.ts
@@ -90,6 +90,10 @@ await main(function* () {
   logger.dir(cost.summary());
 
   yield* stitch();
+
+  if (!Deno.args.includes("local")) {
+    yield* cache.clear();
+  }
   
   logger.log("Done ✅");
 });

--- a/main.ts
+++ b/main.ts
@@ -12,6 +12,7 @@ import { encodeHex } from "jsr:@std/encoding@1";
 import { initRetryWithBackoff } from "./lib/useRetryWithBackoff.ts";
 import { stitch } from "./lib/stitch.ts";
 import { initCostContext } from "./lib/useCost.ts";
+import { parseArgs } from "jsr:@std/cli@1.0.6/parse-args";
 
 await main(function* () {
   yield* initRetryWithBackoff();
@@ -90,12 +91,6 @@ await main(function* () {
   logger.dir(cost.summary());
 
   yield* stitch();
-
-  if (!Deno.args.includes("local")) {
-    yield* cache.clear({ full: true });
-  } else {
-    yield* cache.clear({ full: false });
-  }
   
   logger.log("Done ✅");
 });

--- a/main.ts
+++ b/main.ts
@@ -92,7 +92,9 @@ await main(function* () {
   yield* stitch();
 
   if (!Deno.args.includes("local")) {
-    yield* cache.clear();
+    yield* cache.clear({ full: true });
+  } else {
+    yield* cache.clear({ full: false });
   }
   
   logger.log("Done ✅");


### PR DESCRIPTION
We're going to end up filtering the comments/replies out of discussions that do not have "public" label attached within Backstage. In another words this package is going to query all comments so it's probably best that we don't store that information in `.cache`.