### PR TITLE
Specify registry url for publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 20.x
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Setup Deno
         uses: denoland/setup-deno@v1


### PR DESCRIPTION
![Screenshot 2024-10-16 at 4 23 55 PM](https://github.com/user-attachments/assets/d39f7b82-4b48-4b1e-b0e6-2d8306e90a15)

We needed to specify which registry to publish to. The first workflow failed cause it was using a generic token and we need to use a token specific for CI so that it doesn't prompt for MFA.

![Screenshot 2024-10-16 at 4 25 32 PM](https://github.com/user-attachments/assets/196a2119-9832-4fad-9d54-7b0d66c6995e)