### PR TITLE
Upgraded to effection 4

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -22,6 +22,7 @@
     "npm:@types/node@^22.7.4": "22.7.5",
     "npm:chalk@4.1.2": "4.1.2",
     "npm:effection@3.0.3": "3.0.3",
+    "npm:effection@4.0.0-alpha.1": "4.0.0-alpha.1",
     "npm:graphql@16.8.2": "16.8.2",
     "npm:luxon@3.5.0": "3.5.0",
     "npm:moment@2.30.1": "2.30.1",
@@ -1885,6 +1886,9 @@
     },
     "effection@3.0.3": {
       "integrity": "sha512-9ASCaJ44flDoEKUUJtn9drfIomn2z30sZUw7//crbq+eltMu09AyILcouXwpMkcHR8TsD5hDvTTsOLHswWRxXQ=="
+    },
+    "effection@4.0.0-alpha.1": {
+      "integrity": "sha512-2OjTlOVfz3jVDApBsdC/OVsZ5zmla7uYHRdc7OrxxMx7D6S6EapLfxaR4kJGD1VSZbnrHn/Er2/1PZWMLzrP0w=="
     },
     "electron-to-chromium@1.5.36": {
       "integrity": "sha512-HYTX8tKge/VNp6FGO+f/uVDmUkq+cEfcxYhKf15Akc4M5yxt5YmorwlAitKWjWhWQnKcDRBAQKXkhqqXMqcrjw=="

--- a/deno.lock
+++ b/deno.lock
@@ -23,6 +23,7 @@
     "npm:chalk@4.1.2": "4.1.2",
     "npm:effection@3.0.3": "3.0.3",
     "npm:effection@4.0.0-alpha.1": "4.0.0-alpha.1",
+    "npm:effection@4.0.0-alpha.2": "4.0.0-alpha.2",
     "npm:graphql@16.8.2": "16.8.2",
     "npm:luxon@3.5.0": "3.5.0",
     "npm:moment@2.30.1": "2.30.1",
@@ -1889,6 +1890,9 @@
     },
     "effection@4.0.0-alpha.1": {
       "integrity": "sha512-2OjTlOVfz3jVDApBsdC/OVsZ5zmla7uYHRdc7OrxxMx7D6S6EapLfxaR4kJGD1VSZbnrHn/Er2/1PZWMLzrP0w=="
+    },
+    "effection@4.0.0-alpha.2": {
+      "integrity": "sha512-NIaMKF69TFQpxn+DcXPbPEHaQjO2hqRw65izWGu4RrAnVW5wHoyXgOcYR+xXW/3dVozf4OG3M+eg+yOEF9o9sg=="
     },
     "electron-to-chromium@1.5.36": {
       "integrity": "sha512-HYTX8tKge/VNp6FGO+f/uVDmUkq+cEfcxYhKf15Akc4M5yxt5YmorwlAitKWjWhWQnKcDRBAQKXkhqqXMqcrjw=="

--- a/fetchGithubDiscussions.ts
+++ b/fetchGithubDiscussions.ts
@@ -38,7 +38,7 @@ export function* fetchGithubDiscussions(
     commentsBatchSize,
     repliesBatchSize,
     results,
-    timeout = 90_000,
+    timeout = 360_000,
     clearCacheOnSuccess = true,
   } = options;
 

--- a/fetchGithubDiscussions.ts
+++ b/fetchGithubDiscussions.ts
@@ -1,4 +1,4 @@
-import { each, type Operation, type Queue, spawn } from "npm:effection@3.0.3";
+import { each, type Operation, type Queue, spawn } from "npm:effection@4.0.0-alpha.1";
 import { fetchDiscussions } from "./fetchers/discussion.ts";
 import { initCacheContext } from "./lib/useCache.ts";
 import { GithubGraphqlClient, initGraphQLContext } from "./lib/useGraphQL.ts";

--- a/fetchGithubDiscussions.ts
+++ b/fetchGithubDiscussions.ts
@@ -1,4 +1,4 @@
-import { each, type Operation, type Queue, spawn } from "npm:effection@4.0.0-alpha.1";
+import { each, type Operation, type Queue, spawn } from "npm:effection@4.0.0-alpha.2";
 import { fetchDiscussions } from "./fetchers/discussion.ts";
 import { initCacheContext } from "./lib/useCache.ts";
 import { GithubGraphqlClient, initGraphQLContext } from "./lib/useGraphQL.ts";

--- a/fetchers/comments.ts
+++ b/fetchers/comments.ts
@@ -4,6 +4,7 @@ import { useEntries } from "../lib/useEntries.ts";
 import { Cursor } from "../types.ts";
 import chalk from "npm:chalk@4.1.2";
 import { useLogger } from "../lib/useLogger.ts";
+import type { Node } from "../__generated__/types.ts";
 
 interface fetchCommentsOptions {
   incompleteComments: Cursor[];
@@ -66,29 +67,31 @@ export function* fetchComments({
 
     let commentsCount = 0;
     for (const [_, discussion] of Object.entries(data)) {
-      if (discussion.comments.pageInfo.hasNextPage) {
-        cursors.push({
-          id: discussion.id,
-          first,
-          endCursor: discussion.comments.pageInfo.endCursor,
-        });
-      }
-      commentsCount += discussion.comments.nodes.length;
-      for (const comment of discussion.comments.nodes) {
-        if (comment?.author) {
-          yield* entries.send({
-            type: "comment",
-            id: comment.id,
-            bodyText: comment.bodyText,
-            author: comment.author.login,
-            discussionNumber: comment.discussion.number,
+      if (discussion) {
+        if (discussion.comments.pageInfo.hasNextPage) {
+          cursors.push({
+            id: discussion.id,
+            first,
+            endCursor: discussion.comments.pageInfo.endCursor,
           });
-        } else {
-          logger.log(
-            chalk.gray(`Skipped comment:${comment?.id} because author login is missing.`),
-          );
         }
-      };
+        commentsCount += discussion.comments.nodes.length;
+        for (const comment of discussion.comments.nodes) {
+          if (comment?.author) {
+            yield* entries.send({
+              type: "comment",
+              id: comment.id,
+              bodyText: comment.bodyText,
+              author: comment.author.login,
+              discussionNumber: comment.discussion.number,
+            });
+          } else {
+            logger.log(
+              chalk.gray(`Skipped comment:${comment?.id} because author login is missing.`),
+            );
+          }
+        };
+      }
     }
     logger.log(
       `Retrieved ${chalk.blue(commentsCount, commentsCount > 1 ? "comments" : "comment")} from batch query`,
@@ -122,5 +125,5 @@ type DiscussionsBatchQuery = {
         }
       }[];
     }
-  }
+  } | null;
 } & RateLimit; // 🚨

--- a/fetchers/comments.ts
+++ b/fetchers/comments.ts
@@ -1,4 +1,4 @@
-import { type Operation } from "npm:effection@4.0.0-alpha.1";
+import { type Operation } from "npm:effection@4.0.0-alpha.2";
 import { useGraphQL } from "../lib/useGraphQL.ts";
 import { useEntries } from "../lib/useEntries.ts";
 import { Cursor } from "../types.ts";

--- a/fetchers/comments.ts
+++ b/fetchers/comments.ts
@@ -1,4 +1,4 @@
-import { type Operation } from "npm:effection@3.0.3";
+import { type Operation } from "npm:effection@4.0.0-alpha.1";
 import { useGraphQL } from "../lib/useGraphQL.ts";
 import { useEntries } from "../lib/useEntries.ts";
 import { Cursor } from "../types.ts";

--- a/fetchers/discussion.ts
+++ b/fetchers/discussion.ts
@@ -1,5 +1,5 @@
 import { assert } from "jsr:@std/assert@1.0.3";
-import type { Operation } from "npm:effection@4.0.0-alpha.1";
+import type { Operation } from "npm:effection@4.0.0-alpha.2";
 import type { DiscussionsQuery } from "../__generated__/types.ts";
 import { useEntries } from "../lib/useEntries.ts";
 import { useGraphQL } from "../lib/useGraphQL.ts";

--- a/fetchers/discussion.ts
+++ b/fetchers/discussion.ts
@@ -1,5 +1,5 @@
 import { assert } from "jsr:@std/assert@1.0.3";
-import type { Operation } from "npm:effection@3.0.3";
+import type { Operation } from "npm:effection@4.0.0-alpha.1";
 import type { DiscussionsQuery } from "../__generated__/types.ts";
 import { useEntries } from "../lib/useEntries.ts";
 import { useGraphQL } from "../lib/useGraphQL.ts";

--- a/fetchers/replies.ts
+++ b/fetchers/replies.ts
@@ -1,4 +1,4 @@
-import { type Operation } from "npm:effection@4.0.0-alpha.1";
+import { type Operation } from "npm:effection@4.0.0-alpha.2";
 import { useGraphQL } from "../lib/useGraphQL.ts";
 import { useCache } from "../lib/useCache.ts";
 import { useEntries } from "../lib/useEntries.ts";

--- a/fetchers/replies.ts
+++ b/fetchers/replies.ts
@@ -1,4 +1,4 @@
-import { type Operation } from "npm:effection@3.0.3";
+import { type Operation } from "npm:effection@4.0.0-alpha.1";
 import { useGraphQL } from "../lib/useGraphQL.ts";
 import { useCache } from "../lib/useCache.ts";
 import { useEntries } from "../lib/useEntries.ts";

--- a/lib/ensureContext.ts
+++ b/lib/ensureContext.ts
@@ -1,4 +1,4 @@
-import type { Context as ContextType, Operation } from "npm:effection@3.0.3";
+import type { Context as ContextType, Operation } from "npm:effection@4.0.0-alpha.1";
 
 function isMissingContextError(
   error: unknown,
@@ -8,12 +8,8 @@ function isMissingContextError(
 }
 
 export function* ensureContext<T>(Context: ContextType<T>, init: Operation<T>) {
-  try {
-    return yield* Context;
-  } catch (e) {
-    if (isMissingContextError(e)) {
-      return yield* Context.set(yield* init);
-    }
-    throw e;
+  if (!(yield* Context.get())) {
+    yield* Context.set(yield* init);
   }
+  return yield* Context.expect();
 }

--- a/lib/ensureContext.ts
+++ b/lib/ensureContext.ts
@@ -1,12 +1,5 @@
 import type { Context as ContextType, Operation } from "npm:effection@4.0.0-alpha.1";
 
-function isMissingContextError(
-  error: unknown,
-): error is { name: "MissingContextError" } {
-  return error != null &&
-    (error as { name: string }).name === "MissingContextError";
-}
-
 export function* ensureContext<T>(Context: ContextType<T>, init: Operation<T>) {
   if (!(yield* Context.get())) {
     yield* Context.set(yield* init);

--- a/lib/ensureContext.ts
+++ b/lib/ensureContext.ts
@@ -1,4 +1,4 @@
-import type { Context as ContextType, Operation } from "npm:effection@4.0.0-alpha.1";
+import type { Context as ContextType, Operation } from "npm:effection@4.0.0-alpha.2";
 
 export function* ensureContext<T>(Context: ContextType<T>, init: Operation<T>) {
   if (!(yield* Context.get())) {

--- a/lib/forEach.ts
+++ b/lib/forEach.ts
@@ -1,4 +1,4 @@
-import { type Operation, type Queue} from "npm:effection@4.0.0-alpha.1";
+import { type Operation, type Queue} from "npm:effection@4.0.0-alpha.2";
 
 export function* forEach<T>(
   op: (item: T) => Operation<void>,

--- a/lib/forEach.ts
+++ b/lib/forEach.ts
@@ -1,4 +1,4 @@
-import { type Operation, type Queue} from "npm:effection@3.0.3";
+import { type Operation, type Queue} from "npm:effection@4.0.0-alpha.1";
 
 export function* forEach<T>(
   op: (item: T) => Operation<void>,

--- a/lib/stitch.ts
+++ b/lib/stitch.ts
@@ -1,4 +1,4 @@
-import { type Operation, type Queue } from "npm:effection@3.0.3";
+import { type Operation, type Queue } from "npm:effection@4.0.0-alpha.1";
 import { DiscussionEntries, GithubDiscussionFetcherResult } from "../types.ts";
 import { useCache } from "./useCache.ts";
 import { useLogger } from "./useLogger.ts";

--- a/lib/stitch.ts
+++ b/lib/stitch.ts
@@ -1,4 +1,4 @@
-import { type Operation, type Queue } from "npm:effection@4.0.0-alpha.1";
+import { type Operation, type Queue } from "npm:effection@4.0.0-alpha.2";
 import { DiscussionEntries, GithubDiscussionFetcherResult } from "../types.ts";
 import { useCache } from "./useCache.ts";
 import { useLogger } from "./useLogger.ts";

--- a/lib/toAsyncIterable.ts
+++ b/lib/toAsyncIterable.ts
@@ -1,4 +1,4 @@
-import type { Scope, Queue } from "npm:effection@3.0.3";
+import type { Scope, Queue } from "npm:effection@4.0.0-alpha.1";
 
 export function toAsyncIterable<T>(queue: Queue<T, unknown>, scope: Scope): AsyncIterable<T> {
   return {

--- a/lib/toAsyncIterable.ts
+++ b/lib/toAsyncIterable.ts
@@ -1,4 +1,4 @@
-import type { Scope, Queue } from "npm:effection@4.0.0-alpha.1";
+import type { Scope, Queue } from "npm:effection@4.0.0-alpha.2";
 
 export function toAsyncIterable<T>(queue: Queue<T, unknown>, scope: Scope): AsyncIterable<T> {
   return {

--- a/lib/useCache.ts
+++ b/lib/useCache.ts
@@ -9,7 +9,7 @@ import {
   spawn,
   type Stream,
   stream,
-} from "npm:effection@4.0.0-alpha.1";
+} from "npm:effection@4.0.0-alpha.2";
 
 import { ensureContext } from "./ensureContext.ts";
 import { JSONLinesParseStream } from './jsonlines/parser.ts';

--- a/lib/useCache.ts
+++ b/lib/useCache.ts
@@ -9,7 +9,7 @@ import {
   spawn,
   type Stream,
   stream,
-} from "npm:effection@3.0.3";
+} from "npm:effection@4.0.0-alpha.1";
 
 import { ensureContext } from "./ensureContext.ts";
 import { JSONLinesParseStream } from './jsonlines/parser.ts';
@@ -40,7 +40,7 @@ export function* initCacheContext(options: InitCacheContextOptions) {
 }
 
 export function* useCache(): Operation<Cache> {
-  return yield* CacheContext;
+  return yield* CacheContext.expect();
 }
 
 export function createPersistentCache(options: InitCacheContextOptions): Cache {

--- a/lib/useCost.ts
+++ b/lib/useCost.ts
@@ -1,7 +1,7 @@
 import {
   createContext,
   Operation,
-} from "npm:effection@4.0.0-alpha.1";
+} from "npm:effection@4.0.0-alpha.2";
 import { ensureContext } from "./ensureContext.ts";
 
 interface CostEntries {

--- a/lib/useCost.ts
+++ b/lib/useCost.ts
@@ -1,7 +1,7 @@
 import {
   createContext,
   Operation,
-} from "npm:effection@3.0.3";
+} from "npm:effection@4.0.0-alpha.1";
 import { ensureContext } from "./ensureContext.ts";
 
 interface CostEntries {
@@ -61,5 +61,5 @@ export function* initCostContext() {
 }
 
 export function* useCost(): Operation<Cost> {
-  return yield* CostContext;
+  return yield* CostContext.expect();
 }

--- a/lib/useEntries.ts
+++ b/lib/useEntries.ts
@@ -4,7 +4,7 @@ import {
   createContext,
   Operation,
   resource,
-} from "npm:effection@4.0.0-alpha.1";
+} from "npm:effection@4.0.0-alpha.2";
 import { DiscussionEntries } from "../types.ts";
 
 export const EntriesContext = createContext<Channel<DiscussionEntries, void>>(

--- a/lib/useEntries.ts
+++ b/lib/useEntries.ts
@@ -4,7 +4,7 @@ import {
   createContext,
   Operation,
   resource,
-} from "npm:effection@3.0.3";
+} from "npm:effection@4.0.0-alpha.1";
 import { DiscussionEntries } from "../types.ts";
 
 export const EntriesContext = createContext<Channel<DiscussionEntries, void>>(
@@ -33,5 +33,5 @@ export function* initEntriesContext(): Operation<
 }
 
 export function* useEntries(): Operation<Channel<DiscussionEntries, void>> {
-  return yield* EntriesContext;
+  return yield* EntriesContext.expect();
 }

--- a/lib/useGraphQL.ts
+++ b/lib/useGraphQL.ts
@@ -10,7 +10,7 @@ import {
   each,
   type Operation,
   useAbortSignal,
-} from "npm:effection@4.0.0-alpha.1";
+} from "npm:effection@4.0.0-alpha.2";
 import {
   DocumentNode,
   type OperationDefinitionNode,

--- a/lib/useGraphQL.ts
+++ b/lib/useGraphQL.ts
@@ -10,7 +10,7 @@ import {
   each,
   type Operation,
   useAbortSignal,
-} from "npm:effection@3.0.3";
+} from "npm:effection@4.0.0-alpha.1";
 import {
   DocumentNode,
   type OperationDefinitionNode,

--- a/lib/useJsonWriter.ts
+++ b/lib/useJsonWriter.ts
@@ -1,4 +1,4 @@
-import { call, type Operation, resource } from "npm:effection@4.0.0-alpha.1";
+import { call, type Operation, resource } from "npm:effection@4.0.0-alpha.2";
 
 export type JsonWriter = (data: unknown) => Operation<void>
 

--- a/lib/useJsonWriter.ts
+++ b/lib/useJsonWriter.ts
@@ -1,4 +1,4 @@
-import { call, type Operation, resource } from "npm:effection@3.0.3";
+import { call, type Operation, resource } from "npm:effection@4.0.0-alpha.1";
 
 export type JsonWriter = (data: unknown) => Operation<void>
 

--- a/lib/useLogger.ts
+++ b/lib/useLogger.ts
@@ -1,4 +1,4 @@
-import { createContext, Operation } from "npm:effection@4.0.0-alpha.1";
+import { createContext, Operation } from "npm:effection@4.0.0-alpha.2";
 import { ensureContext } from "./ensureContext.ts";
 
 export type Logger = typeof console;

--- a/lib/useLogger.ts
+++ b/lib/useLogger.ts
@@ -1,4 +1,4 @@
-import { createContext, Operation } from "npm:effection@3.0.3";
+import { createContext, Operation } from "npm:effection@4.0.0-alpha.1";
 import { ensureContext } from "./ensureContext.ts";
 
 export type Logger = typeof console;
@@ -21,5 +21,5 @@ export function* initLoggerContext(logger: Console): Operation<Console> {
 }
 
 export function* useLogger(): Operation<Console> {
-  return yield* LoggerContext;
+  return yield* LoggerContext.expect();
 }

--- a/lib/useRetryWithBackoff.ts
+++ b/lib/useRetryWithBackoff.ts
@@ -1,4 +1,4 @@
-import { createContext, Operation, race, sleep } from "npm:effection@3.0.3";
+import { createContext, Operation, race, sleep } from "npm:effection@4.0.0-alpha.1";
 import { useLogger } from "./useLogger.ts";
 import { ensureContext } from "./ensureContext.ts";
 import moment from "npm:moment@2.30.1";
@@ -22,7 +22,7 @@ export function* useRetryWithBackoff<T>(
   options: UseRetryBackoffOptions,
 ): Operation<void> {
   const logger = yield* useLogger();
-  const defaults = yield* RetryWithBackoffContext;
+  const defaults = yield* RetryWithBackoffContext.expect();
   const _options = {
     ...defaults,
     ...options,

--- a/lib/useRetryWithBackoff.ts
+++ b/lib/useRetryWithBackoff.ts
@@ -48,7 +48,7 @@ export function* useRetryWithBackoff<T>(
         
         logger.debug(e);
         logger.log(
-          `Operation[${_options.operationName}] failed, will retry in ${moment.duration(delayMs).humanize()}.`
+          `Operation[${_options.operationName}] failed, will retry in ${moment.duration(delayMs).humanize({ s: 1, m: 1 })}.`
         );
 
         yield* sleep(delayMs);

--- a/lib/useRetryWithBackoff.ts
+++ b/lib/useRetryWithBackoff.ts
@@ -1,4 +1,4 @@
-import { createContext, Operation, race, sleep } from "npm:effection@4.0.0-alpha.1";
+import { createContext, Operation, race, sleep } from "npm:effection@4.0.0-alpha.2";
 import { useLogger } from "./useLogger.ts";
 import { ensureContext } from "./ensureContext.ts";
 import moment from "npm:moment@2.30.1";

--- a/main.ts
+++ b/main.ts
@@ -1,5 +1,5 @@
 import { assert } from "jsr:@std/assert";
-import { createQueue, main, spawn } from "npm:effection@3.0.3";
+import { createQueue, main, spawn } from "npm:effection@4.0.0-alpha.1";
 import { fetchGithubDiscussions } from "./fetchGithubDiscussions.ts";
 import { forEach } from "./lib/forEach.ts";
 import { createGithubGraphqlClient } from "./lib/useGraphQL.ts";

--- a/main.ts
+++ b/main.ts
@@ -1,5 +1,5 @@
 import { assert } from "jsr:@std/assert";
-import { createQueue, main, spawn } from "npm:effection@4.0.0-alpha.1";
+import { createQueue, main, spawn } from "npm:effection@4.0.0-alpha.2";
 import { fetchGithubDiscussions } from "./fetchGithubDiscussions.ts";
 import { forEach } from "./lib/forEach.ts";
 import { createGithubGraphqlClient } from "./lib/useGraphQL.ts";
@@ -25,7 +25,7 @@ if (import.meta.main) {
         client,
         org: "vercel",
         repo: "next.js",
-        discussionsBatchSize: 50,
+        discussionsBatchSize: 100,
         commentsBatchSize: 100,
         repliesBatchSize: 100,
         results,

--- a/main.ts
+++ b/main.ts
@@ -25,7 +25,7 @@ if (import.meta.main) {
         client,
         org: "vercel",
         repo: "next.js",
-        discussionsBatchSize: 100,
+        discussionsBatchSize: 50,
         commentsBatchSize: 100,
         repliesBatchSize: 100,
         results,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "github-discussions-fetcher",
-  "version": "0.1.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "github-discussions-fetcher",
-      "version": "0.1.0",
+      "version": "0.6.0",
       "license": "ISC",
       "dependencies": {
         "@changesets/cli": "^2.27.9",


### PR DESCRIPTION
# Motivation

Wanted to try Effection 4 and restore `each` so we can use `walk` instead of `walkSync`. 

# Approach

1. Upgraded to effection-4.0.0-beta.2
2. Replaced walkSync with walk
3. Made root node nullable in comments and replies batch queries
