### PR TITLE
Have the build script replace * with workspace versions

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -36,13 +36,10 @@
     "npm:@graphql-codegen/typescript@4": "4.1.1_graphql@16.8.2",
     "npm:@octokit/graphql-schema@^11.1.0": "11.2.0_graphql@16.8.2",
     "npm:@octokit/graphql@^4.8.0": "4.8.0",
-    "npm:@octokit/types@13.6.1": "13.6.1",
     "npm:@types/node@*": "22.5.4",
     "npm:@types/node@^22.7.4": "22.9.0",
     "npm:byte-size@9.0.0": "9.0.0",
     "npm:chalk@4.1.2": "4.1.2",
-    "npm:effection@4.0.0-alpha.3": "4.0.0-alpha.3",
-    "npm:github-discussions-fetcher@0.7.4": "0.7.4",
     "npm:graphql@16.8.2": "16.8.2",
     "npm:pretty-ms@9.2.0": "9.2.0",
     "npm:typescript@^5.6.2": "5.6.3"
@@ -765,16 +762,6 @@
         "prettier"
       ]
     },
-    "@deno/shim-deno-test@0.5.0": {
-      "integrity": "sha512-4nMhecpGlPi0cSzT67L+Tm+GOJqvuk8gqHBziqcUQOarnuIax1z96/gJHCSIz2Z0zhxE6Rzwb3IZXPtFh51j+w=="
-    },
-    "@deno/shim-deno@0.18.2": {
-      "integrity": "sha512-oQ0CVmOio63wlhwQF75zA4ioolPvOwAoK0yuzcS5bDC1JUvH3y1GS8xPh8EOpcoDQRU4FTG8OQfxhpR+c6DrzA==",
-      "dependencies": [
-        "@deno/shim-deno-test",
-        "which@4.0.0"
-      ]
-    },
     "@graphql-codegen/add@3.2.3_graphql@16.8.2": {
       "integrity": "sha512-sQOnWpMko4JLeykwyjFTxnhqjd/3NOG2OyMuvK76Wnnwh8DRrNf2VEs2kmSvLl7MndMlOj7Kh5U154dVcvhmKQ==",
       "dependencies": [
@@ -1360,7 +1347,7 @@
     "@octokit/endpoint@6.0.12": {
       "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
       "dependencies": [
-        "@octokit/types@6.41.0",
+        "@octokit/types",
         "is-plain-object",
         "universal-user-agent"
       ]
@@ -1376,20 +1363,17 @@
       "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
       "dependencies": [
         "@octokit/request",
-        "@octokit/types@6.41.0",
+        "@octokit/types",
         "universal-user-agent"
       ]
     },
     "@octokit/openapi-types@12.11.0": {
       "integrity": "sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ=="
     },
-    "@octokit/openapi-types@22.2.0": {
-      "integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg=="
-    },
     "@octokit/request-error@2.1.0": {
       "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
       "dependencies": [
-        "@octokit/types@6.41.0",
+        "@octokit/types",
         "deprecation",
         "once"
       ]
@@ -1399,22 +1383,16 @@
       "dependencies": [
         "@octokit/endpoint",
         "@octokit/request-error",
-        "@octokit/types@6.41.0",
+        "@octokit/types",
         "is-plain-object",
         "node-fetch",
         "universal-user-agent"
       ]
     },
-    "@octokit/types@13.6.1": {
-      "integrity": "sha512-PHZE9Z+kWXb23Ndik8MKPirBPziOc0D2/3KH1P+6jK5nGWe96kadZuE4jev2/Jq7FvIfTlT2Ltg8Fv2x1v0a5g==",
-      "dependencies": [
-        "@octokit/openapi-types@22.2.0"
-      ]
-    },
     "@octokit/types@6.41.0": {
       "integrity": "sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==",
       "dependencies": [
-        "@octokit/openapi-types@12.11.0"
+        "@octokit/openapi-types"
       ]
     },
     "@parcel/watcher-android-arm64@2.5.0": {
@@ -1915,7 +1893,7 @@
       "dependencies": [
         "lru-cache@4.1.5",
         "shebang-command",
-        "which@1.3.1"
+        "which"
       ]
     },
     "dataloader@2.2.2": {
@@ -1969,9 +1947,6 @@
     },
     "dset@3.1.4": {
       "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA=="
-    },
-    "effection@4.0.0-alpha.3": {
-      "integrity": "sha512-GIzNiia4UFKBbKSv4ElWk1XpSp/8iKGBmz1Yud1XkGtJfKQD9tNLk4Me9OqYlhUW6jUTzJuAqFvylc88wLGqeg=="
     },
     "electron-to-chromium@1.5.62": {
       "integrity": "sha512-t8c+zLmJHa9dJy96yBZRXGQYoiCEnHYgFwn1asvSPZSUdVxnB62A4RASd7k41ytG3ErFBA0TpHlKg9D9SQBmLg=="
@@ -2110,18 +2085,6 @@
     },
     "get-caller-file@2.0.5": {
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
-    },
-    "github-discussions-fetcher@0.7.4": {
-      "integrity": "sha512-yjj/Kh3+iOROOaWEHZ59xfQg+lkieD7iffUV3q9h3+IgsqSD2OxFv2lfqXaO3zCdrWuqURMTSDn+B4AND4L3Zw==",
-      "dependencies": [
-        "@deno/shim-deno",
-        "@octokit/graphql",
-        "@octokit/types@13.6.1",
-        "chalk",
-        "effection",
-        "graphql",
-        "moment"
-      ]
     },
     "glob-parent@5.1.2": {
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
@@ -2359,9 +2322,6 @@
     "isexe@2.0.0": {
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
-    "isexe@3.1.1": {
-      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ=="
-    },
     "isomorphic-ws@5.0.0_ws@8.18.0": {
       "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
       "dependencies": [
@@ -2523,9 +2483,6 @@
       "dependencies": [
         "brace-expansion@2.0.1"
       ]
-    },
-    "moment@2.30.1": {
-      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how=="
     },
     "mri@1.2.0": {
       "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="
@@ -3088,13 +3045,7 @@
     "which@1.3.1": {
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dependencies": [
-        "isexe@2.0.0"
-      ]
-    },
-    "which@4.0.0": {
-      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
-      "dependencies": [
-        "isexe@3.1.1"
+        "isexe"
       ]
     },
     "wrap-ansi@6.2.0": {
@@ -3192,11 +3143,11 @@
     "members": {
       "packages/backstage-github-discussions-fetcher": {
         "dependencies": [
-          "npm:github-discussions-fetcher@0.7.4"
+          "npm:github-discussions-fetcher@*"
         ],
         "packageJson": {
           "dependencies": [
-            "npm:github-discussions-fetcher@0.8"
+            "npm:github-discussions-fetcher@*"
           ]
         }
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2436,6 +2436,10 @@
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
+    "node_modules/@guidanti/backstage-github-discussions-fetcher": {
+      "resolved": "packages/backstage-github-discussions-fetcher",
+      "link": true
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
@@ -6378,8 +6382,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "packages/backstage-github-discussions-fetcher": {
+      "name": "@guidanti/backstage-github-discussions-fetcher",
+      "version": "0.4.0",
+      "license": "ISC",
+      "dependencies": {
+        "github-discussions-fetcher": "*"
+      }
+    },
     "packages/github-discussions-fetcher": {
-      "version": "0.7.4",
+      "version": "0.8.0",
       "license": "ISC",
       "dependencies": {
         "@graphql-codegen/cli": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@changesets/cli": "^2.27.9"
   },
   "workspaces": [
-    "packages/*"
+    "packages/backstage-github-discussions-fetcher",
+    "packages/github-discussions-fetcher"
   ]
 }

--- a/packages/backstage-github-discussions-fetcher/deno.json
+++ b/packages/backstage-github-discussions-fetcher/deno.json
@@ -4,6 +4,6 @@
     "build:npm": "deno run -A ../../tasks/build-npm.ts"
   },
   "imports": {
-    "fetchGithubDiscussions": "npm:github-discussions-fetcher@0.7.4"
+    "fetchGithubDiscussions": "npm:github-discussions-fetcher@*"
   }
 }

--- a/packages/backstage-github-discussions-fetcher/package.json
+++ b/packages/backstage-github-discussions-fetcher/package.json
@@ -12,6 +12,6 @@
     "url": "https://github.com/guidanti/graphql-github-discussions/issues"
   },
   "dependencies": {
-    "github-discussions-fetcher": "workspace:*"
+    "github-discussions-fetcher": "*"
   }
 }


### PR DESCRIPTION
Our last PR merge didn't create a versions PR because `"my-package": "workspace:*"` syntax is a feature of yarn.

I updated the build script to look for existing packages in the monorepo. If a dependency of a package is available in the monorepo, it will use the version specified for that package during the build step.

This should allow us to not have to bump the fetcher version manually in the backstage adapter package each time we make changes to the fetcher. (That's what I was hoping it would do with `workspace:*`).