### PR TITLE
Bump Effection to alpha.5

### DIFF
--- a/.changeset/khaki-lobsters-report.md
+++ b/.changeset/khaki-lobsters-report.md
@@ -1,0 +1,6 @@
+---
+"@guidanti/backstage-github-discussions-fetcher": minor
+"github-discussions-fetcher": minor
+---
+
+Bump effection to alpha.5

--- a/deno.lock
+++ b/deno.lock
@@ -42,6 +42,7 @@
     "npm:byte-size@9.0.0": "9.0.0",
     "npm:chalk@4.1.2": "4.1.2",
     "npm:effection@4.0.0-alpha.3": "4.0.0-alpha.3",
+    "npm:effection@4.0.0-alpha.5": "4.0.0-alpha.5",
     "npm:graphql@16.8.2": "16.8.2",
     "npm:pretty-ms@7.0.1": "7.0.1",
     "npm:pretty-ms@9.2.0": "9.2.0",
@@ -1962,6 +1963,9 @@
     },
     "effection@4.0.0-alpha.3": {
       "integrity": "sha512-GIzNiia4UFKBbKSv4ElWk1XpSp/8iKGBmz1Yud1XkGtJfKQD9tNLk4Me9OqYlhUW6jUTzJuAqFvylc88wLGqeg=="
+    },
+    "effection@4.0.0-alpha.5": {
+      "integrity": "sha512-7s8dwQF8oqOxtsUrFMRQBUOWXq23Khb/IYurwqEnSTUwsgkSgQww/9A9aBwdRQ1hMmELouy/YkvhC7e9oGQfbA=="
     },
     "electron-to-chromium@1.5.62": {
       "integrity": "sha512-t8c+zLmJHa9dJy96yBZRXGQYoiCEnHYgFwn1asvSPZSUdVxnB62A4RASd7k41ytG3ErFBA0TpHlKg9D9SQBmLg=="

--- a/packages/backstage-github-discussions-fetcher/lib/fetchDiscussionDocuments.ts
+++ b/packages/backstage-github-discussions-fetcher/lib/fetchDiscussionDocuments.ts
@@ -4,7 +4,7 @@ import {
   type Operation,
   spawn,
   suspend,
-} from 'npm:effection@4.0.0-alpha.3';
+} from 'npm:effection@4.0.0-alpha.5';
 import {
   fetchGithubDiscussions,
   type GithubDiscussionFetcherResult,

--- a/packages/backstage-github-discussions-fetcher/main.ts
+++ b/packages/backstage-github-discussions-fetcher/main.ts
@@ -3,7 +3,7 @@ import {
   each,
   main,
   stream,
-} from "npm:effection@4.0.0-alpha.3";
+} from "npm:effection@4.0.0-alpha.5";
 import { createGithubGraphqlClient } from "github-discussions-fetcher";
 import { fetchDiscussionDocuments } from './lib/fetchDiscussionDocuments.ts';
 

--- a/packages/github-discussions-fetcher/fetchGithubDiscussions.ts
+++ b/packages/github-discussions-fetcher/fetchGithubDiscussions.ts
@@ -1,4 +1,4 @@
-import { type Operation, type Queue } from "npm:effection@4.0.0-alpha.3";
+import { type Operation, type Queue } from "npm:effection@4.0.0-alpha.5";
 import { fetchDiscussions } from "./fetchers/discussion.ts";
 import { initCacheContext } from "./lib/useCache.ts";
 import { GithubGraphqlClient, initGraphQLContext } from "./lib/useGraphQL.ts";

--- a/packages/github-discussions-fetcher/fetchers/comments.ts
+++ b/packages/github-discussions-fetcher/fetchers/comments.ts
@@ -1,4 +1,4 @@
-import { type Operation } from "npm:effection@4.0.0-alpha.3";
+import { type Operation } from "npm:effection@4.0.0-alpha.5";
 import { useGraphQL } from "../lib/useGraphQL.ts";
 import { Cursor } from "../types.ts";
 import chalk from "npm:chalk@4.1.2";

--- a/packages/github-discussions-fetcher/fetchers/discussion.ts
+++ b/packages/github-discussions-fetcher/fetchers/discussion.ts
@@ -1,5 +1,5 @@
 import { assert } from "jsr:@std/assert@1.0.3";
-import { type Operation } from "npm:effection@4.0.0-alpha.3";
+import { type Operation } from "npm:effection@4.0.0-alpha.5";
 import type { DiscussionsQuery } from "../__generated__/types.ts";
 import { writeComment, writeDiscussion } from "../lib/entries.ts";
 import { useGraphQL } from "../lib/useGraphQL.ts";

--- a/packages/github-discussions-fetcher/fetchers/replies.ts
+++ b/packages/github-discussions-fetcher/fetchers/replies.ts
@@ -1,4 +1,4 @@
-import { each, type Operation } from "npm:effection@4.0.0-alpha.3";
+import { each, type Operation } from "npm:effection@4.0.0-alpha.5";
 import { useGraphQL } from "../lib/useGraphQL.ts";
 import { useCache } from "../lib/useCache.ts";
 import { writeReply } from "../lib/entries.ts";

--- a/packages/github-discussions-fetcher/lib/ensureContext.ts
+++ b/packages/github-discussions-fetcher/lib/ensureContext.ts
@@ -1,7 +1,7 @@
 import type {
   Context as ContextType,
   Operation,
-} from "npm:effection@4.0.0-alpha.3";
+} from "npm:effection@4.0.0-alpha.5";
 
 export function* ensureContext<T>(Context: ContextType<T>, init: Operation<T>) {
   if (!(yield* Context.get())) {

--- a/packages/github-discussions-fetcher/lib/stitch.ts
+++ b/packages/github-discussions-fetcher/lib/stitch.ts
@@ -1,4 +1,4 @@
-import { each, type Operation, type Queue } from "npm:effection@4.0.0-alpha.3";
+import { each, type Operation, type Queue } from "npm:effection@4.0.0-alpha.5";
 import { DiscussionEntries, GithubDiscussionFetcherResult } from "../types.ts";
 import { useCache } from "./useCache.ts";
 import { useLogger } from "./useLogger.ts";

--- a/packages/github-discussions-fetcher/lib/toAsyncIterable.ts
+++ b/packages/github-discussions-fetcher/lib/toAsyncIterable.ts
@@ -1,4 +1,4 @@
-import type { Queue, Scope } from "npm:effection@4.0.0-alpha.3";
+import type { Queue, Scope } from "npm:effection@4.0.0-alpha.5";
 
 export function toAsyncIterable<T>(
   queue: Queue<T, unknown>,

--- a/packages/github-discussions-fetcher/lib/useCache.ts
+++ b/packages/github-discussions-fetcher/lib/useCache.ts
@@ -9,7 +9,7 @@ import {
   spawn,
   type Stream,
   stream,
-} from "npm:effection@4.0.0-alpha.3";
+} from "npm:effection@4.0.0-alpha.5";
 import fs from "node:fs";
 import { promisify } from "node:util";
 

--- a/packages/github-discussions-fetcher/lib/useCost.ts
+++ b/packages/github-discussions-fetcher/lib/useCost.ts
@@ -1,4 +1,4 @@
-import { createContext, Operation } from "npm:effection@4.0.0-alpha.3";
+import { createContext, Operation } from "npm:effection@4.0.0-alpha.5";
 import { ensureContext } from "./ensureContext.ts";
 
 interface CostEntries {

--- a/packages/github-discussions-fetcher/lib/useGraphQL.ts
+++ b/packages/github-discussions-fetcher/lib/useGraphQL.ts
@@ -10,7 +10,7 @@ import {
   each,
   type Operation,
   useAbortSignal,
-} from "npm:effection@4.0.0-alpha.3";
+} from "npm:effection@4.0.0-alpha.5";
 import {
   DocumentNode,
   type OperationDefinitionNode,

--- a/packages/github-discussions-fetcher/lib/useLogger.ts
+++ b/packages/github-discussions-fetcher/lib/useLogger.ts
@@ -1,4 +1,4 @@
-import { createContext, Operation } from "npm:effection@4.0.0-alpha.3";
+import { createContext, Operation } from "npm:effection@4.0.0-alpha.5";
 import { ensureContext } from "./ensureContext.ts";
 
 export type Logger = typeof console;

--- a/packages/github-discussions-fetcher/lib/useRetryWithBackoff.ts
+++ b/packages/github-discussions-fetcher/lib/useRetryWithBackoff.ts
@@ -3,7 +3,7 @@ import {
   Operation,
   race,
   sleep,
-} from "npm:effection@4.0.0-alpha.3";
+} from "npm:effection@4.0.0-alpha.5";
 import { useLogger } from "./useLogger.ts";
 import { ensureContext } from "./ensureContext.ts";
 import prettyMilliseconds from "npm:pretty-ms@7.0.1";

--- a/packages/github-discussions-fetcher/main.ts
+++ b/packages/github-discussions-fetcher/main.ts
@@ -6,7 +6,7 @@ import {
   type Operation,
   spawn,
   type Subscription,
-} from "npm:effection@4.0.0-alpha.3";
+} from "npm:effection@4.0.0-alpha.5";
 import byteSize from "npm:byte-size@9.0.0";
 import { fetchGithubDiscussions } from "./fetchGithubDiscussions.ts";
 import { createGithubGraphqlClient } from "./lib/useGraphQL.ts";


### PR DESCRIPTION
Bumped all imports of effection to alpha.5 to make it compatible with node 18.

https://github.com/thefrontside/effection/pull/966